### PR TITLE
Make this work for Org and User pages too

### DIFF
--- a/src/Console/PublishGitHubCommand.php
+++ b/src/Console/PublishGitHubCommand.php
@@ -35,7 +35,7 @@ class PublishGitHubCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $packageName = $input->getArgument('package-name');
-        $targetName = $input->getArgument('target-name') ?: $packageName;
+        $targetName = $input->getArgument('target-name');
 
         Manifest::factory($packageName, $targetName)
             ->publish(new Target\GitHub());

--- a/src/Console/PublishGitHubCommand.php
+++ b/src/Console/PublishGitHubCommand.php
@@ -22,7 +22,7 @@ class PublishGitHubCommand extends Command
                 'The package name in vendor/project format'
             )
             ->addArgument(
-                'target-name',
+                'target-package-name',
                 InputArgument::OPTIONAL,
                 'The target repo in vendor/project format'
             )
@@ -35,9 +35,9 @@ class PublishGitHubCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $packageName = $input->getArgument('package-name');
-        $targetName = $input->getArgument('target-name');
+        $targetPackageName = $input->getArgument('target-package-name');
 
-        Manifest::factory($packageName, $targetName)
+        Manifest::factory($packageName, $targetPackageName)
             ->publish(new Target\GitHub());
     }
 }

--- a/src/Console/PublishGitHubCommand.php
+++ b/src/Console/PublishGitHubCommand.php
@@ -17,9 +17,14 @@ class PublishGitHubCommand extends Command
             ->setName('publish:gh-pages')
             ->setDescription('Update and publish a manifest to GitHub Pages')
             ->addArgument(
-               'package-name',
-               InputArgument::REQUIRED,
-               'The package name in vendor/project format'
+                'package-name',
+                InputArgument::REQUIRED,
+                'The package name in vendor/project format'
+            )
+            ->addArgument(
+                'target-name',
+                InputArgument::OPTIONAL,
+                'The target repo in vendor/project format'
             )
         ;
     }
@@ -29,8 +34,10 @@ class PublishGitHubCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $manifest = Manifest::factory($input->getArgument('package-name'))
-          ->publish(new Target\GitHub())
-        ;
+        $packageName = $input->getArgument('package-name');
+        $targetName = $input->getArgument('target-name') ?: $packageName;
+
+        Manifest::factory($packageName, $targetName)
+            ->publish(new Target\GitHub());
     }
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -29,14 +29,14 @@ class Manifest
 
     /**
      * @param string $packageName
-     * @param string $targetName
+     * @param string $targetPackageName
      *
      * @return Manifest
      */
-    public static function factory($packageName, $targetName = null)
+    public static function factory($packageName, $targetPackageName = null)
     {
         $repository = new Repository($packageName);
-        $targetRepository = ($targetName) ? new Repository($targetName) : null;
+        $targetRepository = $targetPackageName ? new Repository($targetPackageName) : null;
 
         return new static($repository, $targetRepository);
     }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -14,12 +14,17 @@ class Manifest
     protected $repository;
 
     /**
+     * @var Repository
+     */
+    protected $targetRepository;
+
+    /**
      * @param Repository $repository
      */
-    public function __construct(Repository $repository, Repository $targetRepository)
+    public function __construct(Repository $repository, Repository $targetRepository = null)
     {
         $this->repository = $repository;
-        $this->targetRepository = $targetRepository;
+        $this->targetRepository = $targetRepository ?: $repository;
     }
 
     /**
@@ -28,9 +33,12 @@ class Manifest
      *
      * @return Manifest
      */
-    public static function factory($packageName, $targetName)
+    public static function factory($packageName, $targetName = null)
     {
-        return new static(new Repository($packageName), new Repository($targetName));
+        $repository = new Repository($packageName);
+        $targetRepository = ($targetName) ? new Repository($targetName) : null;
+
+        return new static($repository, $targetRepository);
     }
 
     /**

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -16,19 +16,21 @@ class Manifest
     /**
      * @param Repository $repository
      */
-    public function __construct(Repository $repository)
+    public function __construct(Repository $repository, Repository $targetRepository)
     {
         $this->repository = $repository;
+        $this->targetRepository = $targetRepository;
     }
 
     /**
      * @param string $packageName
+     * @param string $targetName
      *
      * @return Manifest
      */
-    public static function factory($packageName)
+    public static function factory($packageName, $targetName)
     {
-        return new static(new Repository($packageName));
+        return new static(new Repository($packageName), new Repository($targetName));
     }
 
     /**
@@ -77,7 +79,7 @@ class Manifest
     public function publish(TargetInterface $target)
     {
         $json = $this->jsonEncode($this->build($target));
-        $target->publishManifest($this->repository, $json);
+        $target->publishManifest($this->targetRepository, $json);
     }
 
     /**

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -68,7 +68,7 @@ class Repository
         }
 
         if ($tag !== null) {
-            $git->checkout($tag);
+            $git->checkout($tag, ['f' => true]);
         }
 
         return $git;

--- a/src/Target/GitHub.php
+++ b/src/Target/GitHub.php
@@ -51,7 +51,7 @@ class GitHub implements TargetInterface
     {
         $git = $this->checkoutGitHubPages($repository);
 
-        file_put_contents($git->getDirectory() . '/manifest.json', $json);
+        file_put_contents($git->getDirectory() . '/manifest.json', $json . PHP_EOL);
         $git->add('manifest.json');
 
         if ($git->hasChanges()) {

--- a/src/Target/GitHub.php
+++ b/src/Target/GitHub.php
@@ -22,7 +22,11 @@ class GitHub implements TargetInterface
         $directory = $this->getPharDirectory($repository, $version);
         $filepath  = $directory . '/' . basename($url);
 
-        $this->downloadFile($url, $filepath, $overwrite);
+        try {
+            $this->downloadFile($url, $filepath, $overwrite);
+        } catch (\RuntimeException $e) {
+            return false;
+        }
         return $filepath;
     }
 

--- a/src/Target/GitHub.php
+++ b/src/Target/GitHub.php
@@ -69,6 +69,8 @@ class GitHub implements TargetInterface
      */
     public function checkoutGitHubPages(Repository $repository)
     {
+        $isProjectPage = !preg_match('#\.github\.io$#', $repository->getPackageName());
+        $branch = $isProjectPage ? 'gh-pages' : 'master';
         $directory = $this->getGitHubPagesDirectory($repository);
         $git = $repository->getGitWrapper()->workingCopy($directory);
 
@@ -77,7 +79,7 @@ class GitHub implements TargetInterface
         }
 
         $git
-            ->checkout('gh-pages')
+            ->checkout($branch)
             ->pull()
         ;
 


### PR DESCRIPTION
- Allow passing a target repository for GitHub pages (needed when you have a separate `*.github.io` repo)
- Detect correct branch to use (`gh-pages` for project pages vs `master` for user/org pages)
- No longer throws an exception when an older release is missing a `.phar` file (it just get skipped and won't appear in `manifest.json`)
- Uses force checkout so there aren't exceptions changing branches ('You have local changes to "X"; cannot switch branches.')

```console
$ php manifest.phar publish:gh-pages ApiGen/ApiGen ApiGen/ApiGen.github.io
```

See https://help.github.com/articles/user-organization-and-project-pages/ for more info.