### PR TITLE
Removes dependency on Guzzle.

### DIFF
--- a/box.json
+++ b/box.json
@@ -5,7 +5,6 @@
         "bin/manifest.php",
         "LICENSE",
         "vendor/cpliakas/git-wrapper/bin/git-ssh-wrapper.sh",
-        "vendor/guzzle/guzzle/src/Guzzle/Http/Resources/cacert.pem",
         "vendor/herrera-io/phar-update/res/schema.json"
     ],
     "finder": [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
         "php": ">=5.4.0",
         "cpliakas/git-wrapper": "~1.0",
         "doctrine/cache": "~1.0",
-        "guzzle/http": ">=3.9.0,<4.0.0",
         "herrera-io/phar-update": "~1.0",
         "symfony/console": "~2.0",
         "symfony/filesystem": "~2.0"

--- a/src/Traits/HttpClient.php
+++ b/src/Traits/HttpClient.php
@@ -2,52 +2,10 @@
 
 namespace Cpliakas\ManifestPublisher\Traits;
 
-use Guzzle\Http\Client;
 use Symfony\Component\Filesystem\Filesystem;
 
 trait HttpClient
 {
-    /**
-     * @var Client
-     */
-    private $httpClient;
-
-    /**
-     * @param  Client $client
-     *
-     * @return Repository
-     */
-    public function setHttpClient(Client $client)
-    {
-        $this->httpClient = $client;
-        return $this;
-    }
-
-    /**
-     * @return Client
-     */
-    public function getHttpClient()
-    {
-        if (!isset($this->httpClient)) {
-            $this->httpClient = new Client();
-        }
-        return $this->httpClient;
-    }
-
-    /**
-     * @param  string $url
-     *
-     * @return array
-     */
-    public function getJson($url)
-    {
-        return $this->getHttpClient()
-            ->get($url)
-            ->send()
-            ->json()
-        ;
-    }
-
     /**
      * @param string  $url
      * @param string  $filename


### PR DESCRIPTION
It appears that there is no code which actually uses Guzzle since @3ffc3f8e.

This commit removes three public methods from the HttpClient trait:
- setHttpClient
- getHttpClient
- getJson

Presently this trait is only used in the Manifest and Github classes.
